### PR TITLE
Auto-connect persistent devices

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -29,6 +29,16 @@ export class AppComponent implements OnInit, OnDestroy {
       // eslint-disable-next-line no-console
       error: e => console.error(e),
     });
+
+    navigator.hid.addEventListener('connect', _event => {
+      // Refresh the whole app on connect
+      window.location.reload();
+    });
+
+    navigator.hid.addEventListener('disconnect', _event => {
+      // Refresh the whole app on disconnect
+      window.location.reload();
+    });
   }
 
   ngOnDestroy(): void {

--- a/src/app/connect/connect.component.ts
+++ b/src/app/connect/connect.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { ManagerService } from '../manager.service';
 
 @Component({
@@ -6,9 +6,14 @@ import { ManagerService } from '../manager.service';
   templateUrl: './connect.component.html',
   styleUrls: ['./connect.component.scss'],
 })
-export class ConnectComponent {
+export class ConnectComponent implements OnInit {
   // eslint-disable-next-line no-useless-constructor
   constructor(private managerService: ManagerService) {}
+
+  ngOnInit(): void {
+    // eslint-disable-next-line no-console
+    this.managerService.reconnectToDevice().catch(e => console.warn(e));
+  }
 
   connect(): void {
     // eslint-disable-next-line no-console

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -1,3 +1,9 @@
+<div class="container" fxLayout="row" fxLayoutAlign="end center">
+  <button mat-raised-button color="primary" (click)="forget()">
+    Forget the device
+  </button>
+</div>
+
 <div class="text-container" fxLayout="row" fxLayoutAlign="space-between start">
   <span class="text battery mat-caption">{{ batteryLife }}</span>
   <span class="mat-h1">{{ title }}</span>

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -42,4 +42,9 @@ export class HeaderComponent implements OnInit {
         console.log(reason);
       });
   }
+
+  forget(): void {
+    // eslint-disable-next-line no-console
+    this.managerService.forgetDevice().catch(e => console.error(e));
+  }
 }

--- a/src/app/manager.service.ts
+++ b/src/app/manager.service.ts
@@ -45,6 +45,16 @@ export class ManagerService {
     }
   }
 
+  async forgetDevice(): Promise<void> {
+    try {
+      await manager.forget();
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error(`Error on devices removal:`, error);
+    }
+    window.location.reload();
+  }
+
   addEventListeners(): void {
     this.device?.on(
       ConfiguratorEvents.CHANGED_CURRENT_CPI,

--- a/src/app/manager.service.ts
+++ b/src/app/manager.service.ts
@@ -45,6 +45,17 @@ export class ManagerService {
     }
   }
 
+  async reconnectToDevice(): Promise<void> {
+    try {
+      const device = await manager.reconnect();
+      this.deviceSubject.next(device);
+      this.addEventListeners();
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log(`Unable to reconnect to device:`, error);
+    }
+  }
+
   async forgetDevice(): Promise<void> {
     try {
       await manager.forget();

--- a/src/lib/ts/manager.ts
+++ b/src/lib/ts/manager.ts
@@ -28,6 +28,21 @@ class Manager {
     return this.backend;
   }
 
+  async reconnect(): Promise<HIDDeviceConfigurator> {
+    const devices = await navigator.hid.getDevices();
+
+    if (!devices.length) return Promise.reject();
+
+    // eslint-disable-next-line no-console
+    console.log(`Looking for backend for: ${devices}`);
+    this.backend = await this.createBackendForDevices(devices);
+
+    // Initialize UI with capabilities, information and current settings
+    this.backend.emit(ConfiguratorEvents.CONNECT);
+
+    return this.backend;
+  }
+
   async forget(): Promise<void> {
     const devices = await navigator.hid.getDevices();
 

--- a/src/lib/ts/manager.ts
+++ b/src/lib/ts/manager.ts
@@ -28,6 +28,14 @@ class Manager {
     return this.backend;
   }
 
+  async forget(): Promise<void> {
+    const devices = await navigator.hid.getDevices();
+
+    devices.forEach(device => {
+      device.forget();
+    });
+  }
+
   async createBackendForDevices(
     devices: HIDDevice[],
   ): Promise<HIDDeviceConfigurator> {


### PR DESCRIPTION
- Added the ability to detect mouse attach/detach and reload the application. This allow to avoid asking the user to connect to the mouse allowed previously. In case if the device have serial ID or connected over BT it is possible to attach/detach the device. But if the serial attribute is not available only PWA reload without asking permission is working.
See rationale: https://bugs.chromium.org/p/chromium/issues/detail?id=958918

-  Added the button into the header allowing to forget the current mouse. Since the initial app has been developed to work with the single mouse, connection to several mouses in the same time cause unpredictable effects.
